### PR TITLE
Fix CountriesSeeder not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ It will generate the `<timestamp>_setup_countries_table.php` migration and the `
 $this->call('CountriesSeeder'); 
 ```
 
+Update composer autoloader:
+
+```bash
+composer dump-autoload
+```
+
 You may now run the migration including the seed.
 ```bash
 $ php artisan migrate --seed


### PR DESCRIPTION
Composer autoload needs to be updated for `DatabaseSeeder::run()` to be able to find `CountriesSeeder`, otherwise you'll get an 
`Class CountriesSeeder does not exist`.